### PR TITLE
重构使用容器编译镜像，拆分编译和启动脚本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
+FROM ibm-semeru-runtimes:open-21-jdk as build
+ENV MAVEN_VENSION=3.9.6
+RUN apt-get update && apt-get install -y curl
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VENSION}/binaries/apache-maven-${MAVEN_VENSION}-bin.tar.gz -o /tmp/apache-maven-${MAVEN_VENSION}-bin.tar.gz && \
+    tar -xzf /tmp/apache-maven-${MAVEN_VENSION}-bin.tar.gz -C /opt && \
+    ln -s /opt/apache-maven-${MAVEN_VENSION}/bin/mvn /usr/local/bin/mvn
+WORKDIR /app
+COPY . .
+RUN mvn clean package
+
 FROM ibm-semeru-runtimes:open-21-jre
-
-ADD target/Jetbrains-Help.jar /Jetbrains-Help.jar
-
-RUN bash -c 'touch /Jetbrains-Help.jar'
-
+WORKDIR /app
+COPY --from=build /app/target/Jetbrains-Help.jar Jetbrains-Help.jar
 ENV TZ=Asia/Shanghai
 RUN ln -sf /usr/share/zoneinfo/{TZ} /etc/localtime && echo "{TZ}" > /etc/timezone
-
-
 EXPOSE 10768
-
-ENTRYPOINT ["java", "-jar","/Jetbrains-Help.jar"]
+ENTRYPOINT ["java", "-jar", "Jetbrains-Help.jar"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker build -t jetbrains-help .

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -1,7 +1,0 @@
-## chmod u+x *.sh
-# please run me ↑
-mvn clean package
-
-docker build -t jenkins-help .
-
-docker run -d -p 10768:10768 --name jetbrains-help jenkins-help

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+docker remove jetbrains-help
+docker run -d -p 10768:10768 --name jetbrains-help jetbrains-help


### PR DESCRIPTION
优化点如标题。

其实感觉彻底剥离源码相关和编译相关到独立目录下好一些，这样子可以规避重复编译的问题，不然根目录改动一readme都要重新编译成新的镜像。

同时，去掉了一些应该不怎么影响用户启动的备注。

`bash build.sh`  即可自动编译镜像，`bash run.sh` 即可根据镜像启动。